### PR TITLE
Fix rails_parallel on generate schema.

### DIFF
--- a/lib/rails_parallel/rake.rb
+++ b/lib/rails_parallel/rake.rb
@@ -218,6 +218,9 @@ module RailsParallel
 
     def generate_schema(digest)
       invoke_task('environment')
+      # This guy is here because db:load_config is a dependency
+      # of db:create, as we change the config in a few lines bellow
+      # running db:create would clobber the config changes.
       invoke_task('db:load_config')
 
       config  = ActiveRecord::Base.configurations[Rails.env].deep_dup


### PR DESCRIPTION
### Problem

Calling `invoke_task('db:create', :force)` will not work if create relies on other tasks.
If `db:create` calls another rake task, for instance, `db:create => "db_charmer:create"` , even if we force on the second time, it would not work as we have to force the parent too.
### Solution

To avoid this type of weird edge cases, we should not use force whatsoever. 

To sum-up my changes:
- I don't call `create` in the beginning anymore, as we can assume the DB exists if running parallel tests.
- Added a `load_config` call, because as we overwrite `ActiveRecord::Base.configurations` we cannot call `load_config` after, otherwise we will lose the values.
- Remove force on `drop` `create` `setup` as they are not necessary anymore.

quickly review
@boourns @camilo @hornairs 
