### PR TITLE
fix drop *rp_scratch dbs

### DIFF
--- a/lib/rails_parallel/rake.rb
+++ b/lib/rails_parallel/rake.rb
@@ -222,8 +222,8 @@ module RailsParallel
           scratch[key] = config[key]
         end
         if SHARD_PATTERN =~ key
-          m = scratch[key] = config[key]#.merge(database:
-          m.merge!(database: m[:database] + '_rp_scratch')
+          m = scratch[key] = config[key]
+          m[:database] += '_rp_scratch'
         end
       end
       scratch


### PR DESCRIPTION
### Problem

Development database was being dropped when re-creating the schema.
### Solution
- Stop using drop rake task
- Drop scratch dbs using activerecord
- Make sure only the [default + shards] dbs are on the scratch config

I tested this local and it worked like a charm =)

review @dylanahsmith  or @hornairs  or @camilo 
cc @odorcicd
