### PR TITLE
added lifecycle hooks and support for simplecov

### DIFF
--- a/bin/rails_parallel_worker
+++ b/bin/rails_parallel_worker
@@ -8,6 +8,22 @@ end
 begin
   start = Time.now
 
+  if ENV['COVERAGE']
+    require 'simplecov'
+
+    coverage_dir = ENV['COVERAGE_DIR']
+    if coverage_dir
+      SimpleCov.coverage_dir(coverage_dir)
+      puts "RP: SimpleCov output directory set to #{coverage_dir}."
+    end
+
+    SimpleCov.start 'rails' do
+      SimpleCov.command_name "#{$$}"
+      puts "RP: SimpleCov enabled for pid=#{$$}.\n"
+    end
+
+  end
+
   rp_master_status 'loading RailsParallel'
   puts 'RP: Loading RailsParallel.'
   $LOAD_PATH << 'lib'
@@ -26,6 +42,8 @@ begin
   elapsed = Time.now - start
   puts "RP: Finished in #{'%.1f' % elapsed} seconds."
   puts 'RP: Shutting down.'
+
+  SimpleCov.result.format! if ENV['COVERAGE']
   Kernel.exit!(0)
 rescue Interrupt, SignalException
   Kernel.exit!(1)

--- a/lib/rails_parallel/runner.rb
+++ b/lib/rails_parallel/runner.rb
@@ -11,6 +11,7 @@ module RailsParallel
 
     @@before_fork = []
     @@after_fork = []
+    @@before_exit = []
 
     def self.before_fork(&block)
       @@before_fork << block
@@ -20,12 +21,20 @@ module RailsParallel
       @@after_fork << block
     end
 
+    def self.before_exit(&block)
+      @@before_exit << block
+    end
+
     def self.run_before_fork
       @@before_fork.each { |p| p.call }
     end
 
     def self.run_after_fork(worker_num)
       @@after_fork.each { |p| p.call(worker_num) }
+    end
+
+    def self.run_before_exit(worker_num)
+      @@before_exit.each { |p| p.call(worker_num) }
     end
 
     def initialize(socket, script)

--- a/lib/rails_parallel/runner/child.rb
+++ b/lib/rails_parallel/runner/child.rb
@@ -30,6 +30,7 @@ module RailsParallel
           ::RailsParallel::Runner.run_after_fork(@number)
 
           main_loop
+          ::RailsParallel::Runner.run_before_exit(@number)
         end
 
         child_socket.close


### PR DESCRIPTION
I'm trying to enable code coverage stats using SimpleCov as part of CircleCI builds.  I've got this basically going but needed a couple of minor changes to rails_parallel.  

_COVERAGE=1 Environment Variable_: SimpleCov handles result merging on the filesystem automatically but we do need to start the coverage listener (i.e. `SimpleCov.start`) and trigger reporting (i.e `SimpleCov.result.format!`) on shutdown.  The rails_parallel_worker does this based on presence of the COVERAGE environment variable.  I tried to keep any knowledge of CircleCI out of this layer so things like the coverage directory are passed down via environment variable (e.g. COVERAGE_DIR).

_Worker Lifecycle_:  We're using the after_fork hooks to start collecting coverage data but we also need to generate reports at the end of the run.  To accomplish this I added a new `run_before_exit` hook which gets run once per child at the end of the main loop.

@wisq  please take a peek.
