### PR TITLE
Loosen redis-rb dep

### DIFF
--- a/rails_parallel.gemspec
+++ b/rails_parallel.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'redis', '~> 3.0.0'
+  s.add_dependency 'redis', '~> 3.0'
   s.add_dependency 'rails', '>= 3.0'
   
   s.add_development_dependency 'minitest', '~> 4.7.4'


### PR DESCRIPTION
@wisq @arthurnn 

Trying to update Shopify to redis-rb 3.1.0 and this is blocking it. Seeing that this gem doesn't do anything beyond the basic redis command set (and redis-rb is following semver), bumping minor versions shouldn't be an issue.

:v: 
